### PR TITLE
Change from learning.cisco.com to developer.cisco.com/learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 These self-paced interactive tutorials provide instructions for developers to run apps on edge devices in their network hardware.
 
-Labs are written to be displayed within the [Cisco DevNet Learning Labs system](https://learninglabs.cisco.com).
+Labs are written to be displayed within the [Cisco DevNet Learning Labs system](https://developer.cisco.com/learning).
 
 Contributions are welcome, and we are glad to review changes through pull requests. See [contributing.md](contributing.md) for details.
 

--- a/contributing.md
+++ b/contributing.md
@@ -16,7 +16,7 @@ For public repo Learning Labs, use the issue tracker in the repo. All Learning L
 
 For private Learning Labs, use the common Issue tracker in the [CiscoDevNet/learning-labs-issues](https://github.com/CiscoDevNet/learning-labs-issues) repo.
 
-For DevNet Express events, use these three Issue tracker repos based on the content track:
+For DevNet Express events, use these Issue tracker repos based on the content track:
 * https://github.com/CiscoDevNet/devnet-express-dna-issues
 * https://github.com/CiscoDevNet/devnet-express-cc-issues
 * https://github.com/CiscoDevNet/devnet-express-dci-issues

--- a/contributing.md
+++ b/contributing.md
@@ -20,6 +20,7 @@ For DevNet Express events, use these three Issue tracker repos based on the cont
 * https://github.com/CiscoDevNet/devnet-express-dna-issues
 * https://github.com/CiscoDevNet/devnet-express-cc-issues
 * https://github.com/CiscoDevNet/devnet-express-dci-issues
+* https://github.com/CiscoDevNet/devnet-express-security-issues
 
 Use the issue tracker to suggest additions, report bugs, and ask questions.
 This is also a great way to connect with the developers of the project as well

--- a/labs/linx_at_the_edge/1.md
+++ b/labs/linx_at_the_edge/1.md
@@ -9,7 +9,7 @@ Completion Time: 20 Minutes
 - Platform and software support for the guest shell
 
 # Prerequisites
-To prepare your computer for this lab, click the "How to Set Up Your Computer" link at the top of this lab. Please ensure you have completed [Cloud to Fog… Why Host Apps in the Network](https://learninglabs.cisco.com/modules/net_app_hosting/cloud_to_fog/step/1) lab beforehand.
+To prepare your computer for this lab, click the "How to Set Up Your Computer" link at the top of this lab. Please ensure you have completed [Cloud to Fog… Why Host Apps in the Network](https://developer.cisco.com/learning/modules/net_app_hosting/cloud_to_fog/step/1) lab beforehand.
 
 
 ## Enabling Guest Shell

--- a/labs/python_at_the_Edge/1.md
+++ b/labs/python_at_the_Edge/1.md
@@ -11,7 +11,7 @@ Completion Time: 20 Minutes
 
 # Prerequisites
 To prepare your computer for this lab, click the "How to Set Up Your Computer" link at the top of this lab.
-Please ensure you have completed [Linux at the Edge: Introduction to Guest Shell](https://learninglabs.cisco.com/modules/net_app_hosting/linx_at_the_edge/step/1) lab beforehand.
+Please ensure you have completed [Linux at the Edge: Introduction to Guest Shell](https://developer.cisco.com/learning/modules/net_app_hosting/linx_at_the_edge/step/1) lab beforehand.
 
 ## Cisco Guest Shell Capabilities
 


### PR DESCRIPTION
Want to test URLs once Learning Labs site is back up.